### PR TITLE
Fixes for building under Node.js v0.10.2

### DIFF
--- a/src/odbc.h
+++ b/src/odbc.h
@@ -46,7 +46,7 @@ typedef struct {
   SQLSMALLINT  type;
   SQLLEN       size;
   void        *buffer;
-  SQLLEN       buffer_length;    
+  SQLLEN       buffer_length;
   SQLLEN       length;
   SQLSMALLINT  decimals;
 } Parameter;
@@ -56,18 +56,18 @@ class ODBC : public node::ObjectWrap {
     static Persistent<FunctionTemplate> constructor_template;
     static uv_mutex_t g_odbcMutex;
     static uv_async_t g_async;
-    
+
     static void Init(v8::Handle<Object> target);
     static Column* GetColumns(SQLHSTMT hStmt, short* colCount);
     static void FreeColumns(Column* columns, short* colCount);
     static Handle<Value> GetColumnValue(SQLHSTMT hStmt, Column column, uint16_t* buffer, int bufferLength);
     static Handle<Value> GetRecordTuple (SQLHSTMT hStmt, Column* columns, short* colCount, uint16_t* buffer, int bufferLength);
     static Handle<Value> GetRecordArray (SQLHSTMT hStmt, Column* columns, short* colCount, uint16_t* buffer, int bufferLength);
-    
+
     static Parameter* GetParametersFromArray (Local<Array> values, int* paramCount);
-    
+
     void Free();
-    
+
   protected:
     ODBC() {}
 
@@ -78,33 +78,37 @@ class ODBC : public node::ObjectWrap {
     //Property Getter/Setters
     static Handle<Value> ModeGetter(Local<String> property, const AccessorInfo &info);
     static void ModeSetter(Local<String> property, Local<Value> value, const AccessorInfo &info);
-    
+
     static Handle<Value> ConnectedGetter(Local<String> property, const AccessorInfo &info);
-    
+
+    static void UV_AfterOpen(uv_work_t* req, int status);
     static void UV_AfterOpen(uv_work_t* req);
     static void UV_Open(uv_work_t* req);
     static Handle<Value> Open(const Arguments& args);
 
+    static void UV_AfterClose(uv_work_t* req, int status);
     static void UV_AfterClose(uv_work_t* req);
     static void UV_Close(uv_work_t* req);
     static Handle<Value> Close(const Arguments& args);
 
+    static void UV_AfterQuery(uv_work_t* req, int status);
     static void UV_AfterQuery(uv_work_t* req);
     static void UV_Query(uv_work_t* req);
     static Handle<Value> Query(const Arguments& args);
 
+    static void UV_AfterQueryAll(uv_work_t* req, int status);
     static void UV_AfterQueryAll(uv_work_t* req);
     static void UV_QueryAll(uv_work_t* req);
     static Handle<Value> QueryAll(const Arguments& args);
-    
+
     static void UV_Tables(uv_work_t* req);
     static Handle<Value> Tables(const Arguments& args);
 
     static void UV_Columns(uv_work_t* req);
     static Handle<Value> Columns(const Arguments& args);
-  
+
     static void WatcherCallback(uv_async_t* w, int revents);
-    
+
     ODBC *self(void) { return this; }
 
   protected:

--- a/src/odbc_result.h
+++ b/src/odbc_result.h
@@ -22,18 +22,18 @@ class ODBCResult : public node::ObjectWrap {
   public:
    static Persistent<FunctionTemplate> constructor_template;
    static void Init(v8::Handle<Object> target);
-   
+
    void Free();
-   
+
   protected:
     ODBCResult() {};
-    
-    explicit ODBCResult(HENV hENV, HDBC hDBC, HSTMT hSTMT): 
+
+    explicit ODBCResult(HENV hENV, HDBC hDBC, HSTMT hSTMT):
       ObjectWrap(),
       m_hENV(hENV),
       m_hDBC(hDBC),
       m_hSTMT(hSTMT) {};
-     
+
     ~ODBCResult();
 
     //constructor
@@ -42,22 +42,24 @@ class ODBCResult : public node::ObjectWrap {
     //async methods
     static Handle<Value> Fetch(const Arguments& args);
     static void UV_Fetch(uv_work_t* work_req);
+    static void UV_AfterFetch(uv_work_t* work_req, int status);
     static void UV_AfterFetch(uv_work_t* work_req);
 
     static Handle<Value> FetchAll(const Arguments& args);
     static void UV_FetchAll(uv_work_t* work_req);
+    static void UV_AfterFetchAll(uv_work_t* work_req, int status);
     static void UV_AfterFetchAll(uv_work_t* work_req);
-    
+
     //sync methods
     static Handle<Value> Close(const Arguments& args);
     static Handle<Value> MoreResults(const Arguments& args);
-    
+
     struct Fetch_Request {
       Persistent<Function> callback;
       ODBCResult *objResult;
       SQLRETURN result;
     };
-    
+
     ODBCResult *self(void) { return this; }
 
   protected:


### PR DESCRIPTION
Added overloads of `UV_After*` to match the definition of `uv_after_work_cb` in the latest Node.js.

Fixes https://github.com/w1nk/node-odbc/issues/34
