### PR TITLE
Improper check of return codes in ODBC::GetColumnValue leads to infinite malloc loop 

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -568,9 +568,12 @@ Handle<Value> ODBC::GetColumnValue( SQLHSTMT hStmt, Column column,
         }
         else {
           //an error has occured
+          //possible values for ret are SQL_ERROR (-1) and SQL_INVALID_HANDLE (-2)
           char *errorMessage = "ODBC::GetColumnValue - String: - ERROR";
           DEBUG_PRINTF("%s\n", errorMessage);
           
+          
+          //What's the right way to handle errors here????
           Local<Object> objError = Object::New();
           objError->SetPrototype(Exception::Error(String::New(errorMessage)));
           objError->Set(String::New("message"), String::New(errorMessage));


### PR DESCRIPTION
ODBC::GetColumnValue is not prepared for return codes SQL_ERROR and SQL_INVALID_HANDLE and goes into an infinite loop allocating memory when either of those is returned.

Here's a test script that will cause it to happen.
https://gist.github.com/theduderog/6426954

I'm working on Ubuntu 12.10, node 0.10.15, unixodbc 2.2.14, and libsqlliteodbc 0.91-3.

If I compile node-odbc with DEBUG enabled and  UNICODE off, things work ok until I see calls to 

ODBC::~ODBC
ODBC::Free
ODBCConnection::~ODBCConnection
ODBCConnection::Free

From then on, all calls return SQL_INVALID_HANDLE
