### PR TITLE
Fix for segfault 11 on OSX

### DIFF
--- a/src/odbc_result.cpp
+++ b/src/odbc_result.cpp
@@ -310,10 +310,10 @@ void ODBCResult::UV_AfterFetch(uv_work_t* work_req, int status) {
     }
   }
   
+  data->objResult->Unref();
+  
   free(data);
   free(work_req);
-  
-  data->objResult->Unref();
   
   return;
 }


### PR DESCRIPTION
This was causing Segmentation Fault 11 on OSX. Plus it's just probably not a good idea to access memory after it's been freed ;)
