### PR TITLE
Fixed memory leak in ODBC::GetParametersFromArray

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -663,8 +663,12 @@ Parameter* ODBC::GetParametersFromArray (Local<Array> values, int *paramCount) {
   DEBUG_PRINTF("ODBC::GetParametersFromArray\n");
   *paramCount = values->Length();
   
-  Parameter* params = (Parameter *) malloc(*paramCount * sizeof(Parameter));
-
+  Parameter* params = NULL;
+  
+  if (*paramCount > 0) {
+    params = (Parameter *) malloc(*paramCount * sizeof(Parameter));
+  }
+  
   for (int i = 0; i < *paramCount; i++) {
     Local<Value> value = values->Get(i);
     


### PR DESCRIPTION
The bug occurs when a query is being executed with usage of parameters array where array is empty. Something along the lines of 

``` javascript
connection.query('SELECT 1;', [], function (err, result) { ... });
```

In such cases, `ODBC::GetParametersFromArray` is being executed and since `values->Length()` is equal to 0, the call to `malloc` effectively becomes `malloc(0)`. Behavior of such call is not strictly defined. C99 standard states that either a null pointer should be returned or the call should behave as if the requested size was nonzero and a unique pointer is returned with the exception that the address should not be accessed (PDF Warning - [ISO/IEC 9899:TC2](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1124.pdf), section 7.20.3, page 313).

As it stands, `glibc` displays the latter behavior, additionally [defining a minimum allocated size](https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;h=d8fd8b49e4137978e2492942498a0ca5ca5c4c0a;hb=HEAD#l108).

The actual cause of the leak is the fact that in all instances where the parameter array returned by `ODBC::GetParametersFromArray` is freed, it is only done under condition that there were more than 0 parameters in the query - [example](https://github.com/wankdanker/node-odbc/blob/master/src/odbc_connection.cpp#L976).

Given enough time and enough queries, those several lost bytes did pile up.
