### PR TITLE
Added SQLSERVER_STRINGS macro to work around fix for #70.

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -684,17 +684,27 @@ Parameter* ODBC::GetParametersFromArray (Local<Array> values, int *paramCount) {
       Local<String> string = value->ToString();
       int length = string->Length();
       
-      params[i].c_type        = SQL_C_TCHAR;
+      params[i].c_type = SQL_C_TCHAR;
+      params[i].size = params[i].buffer_length;
 #ifdef UNICODE
-      params[i].type          = SQL_WLONGVARCHAR;
+#ifndef SQLSERVER_STRINGS
+      params[i].type = SQL_WLONGVARCHAR;
+#else
+      params[i].type = SQL_WVARCHAR;
+      params[i].size = 0;
+#endif
       params[i].buffer_length = (length * sizeof(uint16_t)) + sizeof(uint16_t);
 #else
-      params[i].type          = SQL_LONGVARCHAR;
+#ifndef SQLSERVER_STRINGS
+      params[i].type = SQL_LONGVARCHAR;
+#else
+      params[i].type = SQL_VARCHAR;
+      params[i].size = 0;
+#endif
       params[i].buffer_length = string->Utf8Length() + 1;
 #endif
-      params[i].buffer        = malloc(params[i].buffer_length);
-      params[i].size          = params[i].buffer_length;
-      params[i].length        = SQL_NTS;//params[i].buffer_length;
+      params[i].buffer = malloc(params[i].buffer_length);
+      params[i].length = SQL_NTS;//params[i].buffer_length;
 
 #ifdef UNICODE
       string->Write((uint16_t *) params[i].buffer);

--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -688,23 +688,23 @@ Parameter* ODBC::GetParametersFromArray (Local<Array> values, int *paramCount) {
       params[i].size = params[i].buffer_length;
 #ifdef UNICODE
 #ifndef SQLSERVER_STRINGS
-      params[i].type = SQL_WLONGVARCHAR;
+      params[i].type          = SQL_WLONGVARCHAR;
 #else
-      params[i].type = SQL_WVARCHAR;
-      params[i].size = 0;
+      params[i].type          = SQL_WVARCHAR;
+      params[i].size          = 0;
 #endif
       params[i].buffer_length = (length * sizeof(uint16_t)) + sizeof(uint16_t);
 #else
 #ifndef SQLSERVER_STRINGS
-      params[i].type = SQL_LONGVARCHAR;
+      params[i].type          = SQL_LONGVARCHAR;
 #else
-      params[i].type = SQL_VARCHAR;
-      params[i].size = 0;
+      params[i].type          = SQL_VARCHAR;
+      params[i].size          = 0;
 #endif
       params[i].buffer_length = string->Utf8Length() + 1;
 #endif
-      params[i].buffer = malloc(params[i].buffer_length);
-      params[i].length = SQL_NTS;//params[i].buffer_length;
+      params[i].buffer        = malloc(params[i].buffer_length);
+      params[i].length        = SQL_NTS;//params[i].buffer_length;
 
 #ifdef UNICODE
       string->Write((uint16_t *) params[i].buffer);


### PR DESCRIPTION
* In SQL Server, SQL_WLONGVARCHAR corresponds to the deprecated ntext data type. nvarchar(max) is the preferred option.
 * To use nvarchar(max), you use SQL_WVARCHAR with a column size of SQL_SS_LENGTH_UNLIMITED (zero). This may or may not probably cause other drivers to send an empty string (?), which is why I've added this as a #define.

This isn't the best solution, since it doesn't support connecting using different drivers at the same time, but I don't know what a better solution would be (any ideas?)