### PR TITLE
Always use SQLExecDirect in UV_Query.

### DIFF
--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -849,51 +849,42 @@ void ODBCConnection::UV_Query(uv_work_t* req) {
 
   uv_mutex_unlock(&ODBC::g_odbcMutex);
 
-  //check to see if should excute a direct or a parameter bound query
-  if (!data->paramCount) {
-    // execute the query directly
-    ret = SQLExecDirect(
-      data->hSTMT,
-      (SQLTCHAR *) data->sql, 
-      data->sqlLen);
-  }
-  else {
-    // prepare statement, bind parameters and execute statement 
-    ret = SQLPrepare(
-      data->hSTMT,
-      (SQLTCHAR *) data->sql, 
-      data->sqlLen);
-    
-    if (ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO) {
-      for (int i = 0; i < data->paramCount; i++) {
-        prm = data->params[i];
-        
-        DEBUG_PRINTF(
-          "ODBCConnection::UV_Query - param[%i]: c_type=%i type=%i "
-          "buffer_length=%i size=%i length=%i &length=%X\n", i, prm.c_type, prm.type, 
-          prm.buffer_length, prm.size, prm.length, &data->params[i].length);
+  // SQLExecDirect will use bound parameters, but without the overhead of SQLPrepare
+  // for a single execution.
+  if (data->paramCount) {
+    for (int i = 0; i < data->paramCount; i++) {
+      prm = data->params[i];
 
-        ret = SQLBindParameter(
-          data->hSTMT,              //StatementHandle
-          i + 1,                    //ParameterNumber
-          SQL_PARAM_INPUT,          //InputOutputType
-          prm.c_type,               //ValueType
-          prm.type,                 //ParameterType
-          prm.size,                 //ColumnSize
-          prm.decimals,             //DecimalDigits
-          prm.buffer,               //ParameterValuePtr
-          prm.buffer_length,        //BufferLength
-          //using &prm.length did not work here...
-          &data->params[i].length); //StrLen_or_IndPtr
-        
-        if (ret == SQL_ERROR) {break;}
-      }
 
-      if (SQL_SUCCEEDED(ret)) {
-        ret = SQLExecute(data->hSTMT);
+      DEBUG_TPRINTF(
+        SQL_T("ODBCConnection::UV_Query - param[%i]: c_type=%i type=%i buffer_length=%i size=%i length=%i &length=%X\n"), i, prm.c_type, prm.type,
+        prm.buffer_length, prm.size, prm.length, &data->params[i].length);
+
+      ret = SQLBindParameter(
+        data->hSTMT,              //StatementHandle
+        i + 1,                    //ParameterNumber
+        SQL_PARAM_INPUT,          //InputOutputType
+        prm.c_type,               //ValueType
+        prm.type,                 //ParameterType
+        prm.size,                 //ColumnSize
+        prm.decimals,             //DecimalDigits
+        prm.buffer,               //ParameterValuePtr
+        prm.buffer_length,        //BufferLength
+        //using &prm.length did not work here...
+        &data->params[i].length); //StrLen_or_IndPtr
+
+      if (ret == SQL_ERROR) {
+        data->result = ret;
+        return;
       }
     }
   }
+
+  // execute the query directly
+  ret = SQLExecDirect(
+    data->hSTMT,
+    (SQLTCHAR *)data->sql,
+    data->sqlLen);
 
   // this will be checked later in UV_AfterQuery
   data->result = ret;

--- a/test/bench-query-fetch-parameters.js
+++ b/test/bench-query-fetch-parameters.js
@@ -1,0 +1,44 @@
+var common = require("./common")
+, odbc = require("../")
+, db = new odbc.Database();
+
+db.open(common.connectionString, function(err){ 
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+  
+  issueQuery();
+});
+
+function issueQuery() {
+  var count = 0
+  , iterations = 10000
+  , time = new Date().getTime();
+
+  function iteration() {
+    db.query("select ? + ?, ? as test", [Math.floor(Math.random() * 1000), Math.floor(Math.random() * 1000), "This is a string"], cb); 
+  }
+
+  iteration()
+    
+  function cb (err, result) {
+    if (err) {
+      console.error("query: ", err);
+      return finish();
+    }
+    
+    if (++count == iterations) {
+      var elapsed = new Date().getTime() - time;
+          
+      console.log("%d queries issued in %d seconds, %d/sec", count, elapsed/1000, Math.floor(count/(elapsed/1000)));
+      return finish();
+    } else {
+      iteration();
+    }
+  }
+  
+  function finish() {
+    db.close(function () {});
+  }
+}

--- a/test/bench-query-fetch.js
+++ b/test/bench-query-fetch.js
@@ -15,14 +15,16 @@ function issueQuery() {
   var count = 0
   , iterations = 10000
   , time = new Date().getTime();
-  
-  for (var x = 0; x < iterations; x++) {
-    db.queryResult("select 1 + 1 as test", cb);
+
+  function iteration() {
+    db.queryResult("select 1 + 1 as test", cb); 
   }
-  
+
+  iteration()
+    
   function cb (err, result) {
     if (err) {
-      console.error(err);
+      console.error("queryResult: ", err);
       return finish();
     }
     
@@ -45,6 +47,8 @@ function issueQuery() {
           
           console.log("%d queries issued in %d seconds, %d/sec", count, elapsed/1000, Math.floor(count/(elapsed/1000)));
           return finish();
+        } else {
+          iteration()
         }
       }
       else {

--- a/test/bench-query-fetchAll.js
+++ b/test/bench-query-fetchAll.js
@@ -16,9 +16,11 @@ function issueQuery() {
   , iterations = 10000
   , time = new Date().getTime();
   
-  for (var x = 0; x < iterations; x++) {
+  function iteration() {
     db.queryResult("select 1 + 1 as test", cb);
   }
+
+  iteration();
   
   function cb (err, result) {
     if (err) {
@@ -39,6 +41,8 @@ function issueQuery() {
           
         console.log("%d queries issued in %d seconds, %d/sec", count, elapsed/1000, Math.floor(count/(elapsed/1000)));
         return finish();
+      } else {
+        iteration();
       }
     });
   }

--- a/test/bench-querySync-parameters.js
+++ b/test/bench-querySync-parameters.js
@@ -1,0 +1,27 @@
+var common = require("./common")
+, odbc = require("../")
+, db = new odbc.Database();
+
+db.open(common.connectionString, function(err){ 
+  if (err) {
+    console.error(err);
+    process.exit(1);
+  }
+  
+  issueQuery();
+});
+
+function issueQuery() {
+  var count = 0
+  , iterations = 10000
+  , time = new Date().getTime();
+
+  for (var x = 0; x < iterations; x++) {
+    db.querySync("select ? + ?, ? as test", [Math.floor(Math.random() * 1000), Math.floor(Math.random() * 1000), "This is a string"]); 
+  }
+
+  var elapsed = new Date().getTime() - time;
+  console.log("%d queries issued in %d seconds, %d/sec", iterations, elapsed/1000, Math.floor(iterations/(elapsed/1000)));
+
+  db.close(function () {});
+}

--- a/test/run-bench.js
+++ b/test/run-bench.js
@@ -32,6 +32,10 @@ function doBench(file, connectionString) {
     doNextBench(connectionString);
   });
   
+  bench.stderr.on("data", function (data) {
+    process.stderr.write(data);
+  });
+    
   bench.stdout.on("data", function (data) {
     process.stdout.write(data);
   });


### PR DESCRIPTION
This should work just as well as ``SQLPrepare``, but with less overhead, since ``SQLExecDirect`` uses bound parameters in the same way. As far as I can see from the documentation, ``SQLPrepare`` is intended for when you will run the same query multiple times using the same ``HSTMT`` (3 to 5 times or more is suggested), whereas ``ODBCConnection::Query`` runs the query once.

In SQL Server, at least, using ``SQLPrepare`` actually creates a temporary stored procedure in the tempdb database (http://msdn.microsoft.com/en-us/library/ms811006.aspx#code-snippet-35). 

I don't think this should reduce performance in other databases, unless in that other database ``SQLPrepare`` then ``SQLExecute`` were faster than ``SQLExecDirect``, which seems unlikely. I don't currently have the setup to test this, do you have a usual way of benchmarking this stuff?

