### PR TITLE
Added pangyp for cross-compatibility build between node.js and io.js.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "odbc",
   "description": "unixodbc bindings for node",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "main": "lib/odbc.js",
   "homepage": "http://github.com/wankdanker/node-odbc/",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -28,13 +28,12 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "install": "pangyp configure build",
+    "install": "node-gyp configure build",
     "test": "cd test && node run-tests.js"
   },
   "dependencies": {
     "bindings": "~1.0.0",
-    "nan": "*1.8.4",
-    "pangyp": "^2.2.0"
+    "nan": "*1.8.4"
   },
   "gypfile": true
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
   },
   "dependencies": {
     "bindings": "~1.0.0",
-    "nan": "^1.8.4",
+    "nan": "^1.8.4"
+  }
+  "devDependencies": {
     "pangyp": "^2.2.0"
   },
   "gypfile": true

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "bindings": "~1.0.0",
     "nan": "^1.8.4"
-  }
+  },
   "devDependencies": {
     "pangyp": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "bindings": "~1.0.0",
-    "nan": "*1.8.4"
+    "nan": "2.0.9"
   },
   "gypfile": true
 }

--- a/package.json
+++ b/package.json
@@ -33,10 +33,8 @@
   },
   "dependencies": {
     "bindings": "~1.0.0",
-    "nan": "^1.8.4"
-  },
-  "devDependencies": {
-    "pangyp": "^2.2.0"
+    "nan": "^1.8.4",
+     "pangyp": "^2.2.0"
   },
   "gypfile": true
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "cd test && node run-tests.js"
   },
   "dependencies": {
-    "bindings": "~1.0.0",
+    "bindings": "*",
     "nan": "*"
   },
   "gypfile": true

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "bindings": "~1.0.0",
-    "nan": "2.0.9"
+    "nan": "*"
   },
   "gypfile": true
 }

--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "install": "node-gyp configure build",
+    "install": "pangyp configure build",
     "test": "cd test && node run-tests.js"
   },
   "dependencies": {
     "bindings": "~1.0.0",
-    "nan": "^1.8.4"
+    "nan": "^1.8.4",
+    "pangyp": "^2.2.0"
   },
   "gypfile": true
 }


### PR DESCRIPTION
pangyp decides between node.js and io.js node-gyp versions.

This allows io.js installs to build node-odbc too.