### PR TITLE
src: fix compilation error on 32-bit linux

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -819,7 +819,7 @@ Local<Object> ODBC::GetSQLError (SQLSMALLINT handleType, SQLHANDLE handle, char*
   
   Local<Object> objError = Nan::New<Object>();
 
-  SQLINTEGER i = 0;
+  int32_t i = 0;
   SQLINTEGER native;
   
   SQLSMALLINT len;


### PR DESCRIPTION
- As SQLINTEGER is defined as long int, cast the error indexes to uint32_t.
  The cast is probably safe as it's highly unlike to have that many errors.