### PR TITLE
Test fixes

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -26,6 +26,9 @@
           ]
         }],
         [ 'OS == "mac"', {
+          'include_dirs': [
+            '/usr/local/include'
+          ],
           'libraries' : [
             '-L/usr/local/lib',
             '-lodbc' 

--- a/lib/odbc.js
+++ b/lib/odbc.js
@@ -66,6 +66,7 @@ function Database(options) {
   }
   
   self.odbc = (options.odbc) ? options.odbc : new odbc.ODBC();
+  self.odbc.domain = process.domain;
   self.queue = new SimpleQueue();
   self.fetchMode = options.fetchMode || null;
   self.connected = false;
@@ -106,6 +107,7 @@ Database.prototype.open = function (connectionString, cb) {
     if (err) return cb(err);
     
     self.conn = conn;
+    self.conn.domain = process.domain;
     
     if (self.connectTimeout || self.connectTimeout === 0) {
       self.conn.connectTimeout = self.connectTimeout;

--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -686,13 +686,12 @@ Parameter* ODBC::GetParametersFromArray (Local<Array> values, int *paramCount) {
 
     if (value->IsString()) {
       Local<String> string = value->ToString();
-      int length = string->Length();
       
       params[i].ValueType         = SQL_C_TCHAR;
       params[i].ColumnSize        = 0; //SQL_SS_LENGTH_UNLIMITED 
 #ifdef UNICODE
       params[i].ParameterType     = SQL_WVARCHAR;
-      params[i].BufferLength      = (length * sizeof(uint16_t)) + sizeof(uint16_t);
+      params[i].BufferLength      = (string->Length() * sizeof(uint16_t)) + sizeof(uint16_t);
 #else
       params[i].ParameterType     = SQL_VARCHAR;
       params[i].BufferLength      = string->Utf8Length() + 1;

--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -226,7 +226,7 @@ void ODBC::UV_AfterCreateConnection(uv_work_t* req, int status) {
     info[0] = Nan::Null();
     info[1] = js_result;
 
-    data->cb->Call(2, info);
+    data->cb->Call(data->dbo->handle(), 2, info);
   }
   
   if (try_catch.HasCaught()) {

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -319,7 +319,7 @@ void ODBCConnection::UV_AfterOpen(uv_work_t* req, int status) {
   Nan::TryCatch try_catch;
 
   data->conn->Unref();
-  data->cb->Call(err ? 1 : 0, argv);
+  data->cb->Call(data->conn->handle(), err ? 1 : 0, argv);
 
   if (try_catch.HasCaught()) {
     Nan::FatalException(try_catch);

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -194,13 +194,13 @@ NAN_METHOD(ODBCConnection::Open) {
   open_connection_work_data* data = (open_connection_work_data *) 
     calloc(1, sizeof(open_connection_work_data));
 
-  data->connectionLength = connection->Length() + 1;
-
   //copy the connection string to the work data  
 #ifdef UNICODE
+  data->connectionLength = connection->Length() + 1;
   data->connection = (uint16_t *) malloc(sizeof(uint16_t) * data->connectionLength);
   connection->Write((uint16_t*) data->connection);
 #else
+  data->connectionLength = connection->Utf8Length() + 1;
   data->connection = (char *) malloc(sizeof(char) * data->connectionLength);
   connection->WriteUtf8((char*) data->connection);
 #endif
@@ -351,12 +351,12 @@ NAN_METHOD(ODBCConnection::OpenSync) {
   SQLRETURN ret;
   bool err = false;
   
-  int connectionLength = connection->Length() + 1;
-  
 #ifdef UNICODE
+  int connectionLength = connection->Length() + 1;
   uint16_t* connectionString = (uint16_t *) malloc(connectionLength * sizeof(uint16_t));
   connection->Write(connectionString);
 #else
+  int connectionLength = connection->Utf8Length() + 1;
   char* connectionString = (char *) malloc(connectionLength);
   connection->WriteUtf8(connectionString);
 #endif
@@ -791,14 +791,15 @@ NAN_METHOD(ODBCConnection::Query) {
   //Done checking arguments
 
   data->cb = new Nan::Callback(cb);
-  data->sqlLen = sql->Length();
 
 #ifdef UNICODE
+  data->sqlLen = sql->Length();
   data->sqlSize = (data->sqlLen * sizeof(uint16_t)) + sizeof(uint16_t);
   data->sql = (uint16_t *) malloc(data->sqlSize);
   sql->Write((uint16_t *) data->sql);
 #else
-  data->sqlSize = sql->Utf8Length() + 1;
+  data->sqlLen = sql->Utf8Length();
+  data->sqlSize = data->sqlLen + 1;
   data->sql = (char *) malloc(data->sqlSize);
   sql->WriteUtf8((char *) data->sql);
 #endif
@@ -1208,7 +1209,7 @@ NAN_METHOD(ODBCConnection::Tables) {
     data->catalog = (uint16_t *) malloc((catalog->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     catalog->Write((uint16_t *) data->catalog);
 #else
-    data->catalog = (char *) malloc(catalog->Length() + 1);
+    data->catalog = (char *) malloc(catalog->Utf8Length() + 1);
     catalog->WriteUtf8((char *) data->catalog);
 #endif
   }
@@ -1218,7 +1219,7 @@ NAN_METHOD(ODBCConnection::Tables) {
     data->schema = (uint16_t *) malloc((schema->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     schema->Write((uint16_t *) data->schema);
 #else
-    data->schema = (char *) malloc(schema->Length() + 1);
+    data->schema = (char *) malloc(schema->Utf8Length() + 1);
     schema->WriteUtf8((char *) data->schema);
 #endif
   }
@@ -1228,7 +1229,7 @@ NAN_METHOD(ODBCConnection::Tables) {
     data->table = (uint16_t *) malloc((table->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     table->Write((uint16_t *) data->table);
 #else
-    data->table = (char *) malloc(table->Length() + 1);
+    data->table = (char *) malloc(table->Utf8Length() + 1);
     table->WriteUtf8((char *) data->table);
 #endif
   }
@@ -1238,7 +1239,7 @@ NAN_METHOD(ODBCConnection::Tables) {
     data->type = (uint16_t *) malloc((type->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     type->Write((uint16_t *) data->type);
 #else
-    data->type = (char *) malloc(type->Length() + 1);
+    data->type = (char *) malloc(type->Utf8Length() + 1);
     type->WriteUtf8((char *) data->type);
 #endif
   }
@@ -1319,7 +1320,7 @@ NAN_METHOD(ODBCConnection::Columns) {
     data->catalog = (uint16_t *) malloc((catalog->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     catalog->Write((uint16_t *) data->catalog);
 #else
-    data->catalog = (char *) malloc(catalog->Length() + 1);
+    data->catalog = (char *) malloc(catalog->Utf8Length() + 1);
     catalog->WriteUtf8((char *) data->catalog);
 #endif
   }
@@ -1329,7 +1330,7 @@ NAN_METHOD(ODBCConnection::Columns) {
     data->schema = (uint16_t *) malloc((schema->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     schema->Write((uint16_t *) data->schema);
 #else
-    data->schema = (char *) malloc(schema->Length() + 1);
+    data->schema = (char *) malloc(schema->Utf8Length() + 1);
     schema->WriteUtf8((char *) data->schema);
 #endif
   }
@@ -1339,7 +1340,7 @@ NAN_METHOD(ODBCConnection::Columns) {
     data->table = (uint16_t *) malloc((table->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     table->Write((uint16_t *) data->table);
 #else
-    data->table = (char *) malloc(table->Length() + 1);
+    data->table = (char *) malloc(table->Utf8Length() + 1);
     table->WriteUtf8((char *) data->table);
 #endif
   }
@@ -1349,7 +1350,7 @@ NAN_METHOD(ODBCConnection::Columns) {
     data->column = (uint16_t *) malloc((column->Length() * sizeof(uint16_t)) + sizeof(uint16_t));
     column->Write((uint16_t *) data->column);
 #else
-    data->column = (char *) malloc(column->Length() + 1);
+    data->column = (char *) malloc(column->Utf8Length() + 1);
     column->WriteUtf8((char *) data->column);
 #endif
   }

--- a/src/odbc_statement.cpp
+++ b/src/odbc_statement.cpp
@@ -439,12 +439,12 @@ NAN_METHOD(ODBCStatement::ExecuteDirect) {
 
   data->cb = new Nan::Callback(cb);
 
-  data->sqlLen = sql->Length();
-
 #ifdef UNICODE
+  data->sqlLen = sql->Length();
   data->sql = (uint16_t *) malloc((data->sqlLen * sizeof(uint16_t)) + sizeof(uint16_t));
   sql->Write((uint16_t *) data->sql);
 #else
+  data->sqlLen = sql->Utf8Length();
   data->sql = (char *) malloc(data->sqlLen +1);
   sql->WriteUtf8((char *) data->sql);
 #endif
@@ -591,15 +591,13 @@ NAN_METHOD(ODBCStatement::PrepareSync) {
 
   SQLRETURN ret;
 
-  int sqlLen = sql->Length() + 1;
-
 #ifdef UNICODE
-  uint16_t *sql2;
-  sql2 = (uint16_t *) malloc(sqlLen * sizeof(uint16_t));
+  int sqlLen = sql->Length() + 1;
+  uint16_t* sql2 = (uint16_t *) malloc(sqlLen * sizeof(uint16_t));
   sql->Write(sql2);
 #else
-  char *sql2;
-  sql2 = (char *) malloc(sqlLen);
+  int sqlLen = sql->Utf8Length() + 1;
+  char* sql2 = (char *) malloc(sqlLen);
   sql->WriteUtf8(sql2);
 #endif
   
@@ -646,12 +644,12 @@ NAN_METHOD(ODBCStatement::Prepare) {
 
   data->cb = new Nan::Callback(cb);
 
-  data->sqlLen = sql->Length();
-
 #ifdef UNICODE
+  data->sqlLen = sql->Length();
   data->sql = (uint16_t *) malloc((data->sqlLen * sizeof(uint16_t)) + sizeof(uint16_t));
   sql->Write((uint16_t *) data->sql);
 #else
+  data->sqlLen = sql->Utf8Length();
   data->sql = (char *) malloc(data->sqlLen +1);
   sql->WriteUtf8((char *) data->sql);
 #endif

--- a/src/odbc_statement.cpp
+++ b/src/odbc_statement.cpp
@@ -832,8 +832,6 @@ NAN_METHOD(ODBCStatement::BindSync) {
     
     info.GetReturnValue().Set(Nan::False());
   }
-
-  info.GetReturnValue().Set(Nan::Undefined());
 }
 
 /*

--- a/test/test-binding-statement-executeSync.js
+++ b/test/test-binding-statement-executeSync.js
@@ -62,7 +62,7 @@ db.createConnection(function (err, conn) {
       console.log(r);
     }
     catch (e) {
-      console.log(e);
+      console.log(e.stack);
       
       exitCode = 1;
     }

--- a/test/test-binding-statement-rebinding.js
+++ b/test/test-binding-statement-rebinding.js
@@ -39,7 +39,7 @@ db.createConnection(function (err, conn) {
       assert.deepEqual(r, [ { col1: 'goodbye', col2: 'steven' } ]);
     }
     catch (e) {
-      console.log(e);
+      console.log(e.stack);
       exitCode = 1;
     }
     

--- a/test/test-binding-statement-rebinding.js
+++ b/test/test-binding-statement-rebinding.js
@@ -5,12 +5,6 @@ var common = require("./common")
   , exitCode = 0
   ;
 
-/*
- * The purpose of this test is to test binding an array and then
- * changing the values of the array before an execute[Sync]
- * call and have the new array values be used.
- */
-  
 db.createConnection(function (err, conn) {
   conn.openSync(common.connectionString);
   
@@ -30,6 +24,7 @@ db.createConnection(function (err, conn) {
     
     a[0] = 'goodbye';
     a[1] = 'steven';
+    stmt.bindSync(a);
     
     result = stmt.executeSync();
     

--- a/test/test-binding-transaction-commitSync.js
+++ b/test/test-binding-transaction-commitSync.js
@@ -22,7 +22,7 @@ db.createConnection(function (err, conn) {
     }
     catch (e) {
       console.log("Failed when rolling back");
-      console.log(e);
+      console.log(e.stack);
       exitCode = 1
     }  
       
@@ -40,7 +40,7 @@ db.createConnection(function (err, conn) {
     }
     catch (e) {
       console.log("Failed when committing");
-      console.log(e);
+      console.log(e.stack);
       
       exitCode = 2;
     }

--- a/test/test-date.js
+++ b/test/test-date.js
@@ -11,6 +11,7 @@ db.open(common.connectionString, function(err) {
   assert.equal(db.connected, true);
   
   var dt = new Date();
+  dt.setMilliseconds(0);  // MySQL truncates them.
   var ds = dt.toISOString().replace('Z','');
   var sql = "SELECT cast('" + ds + "' as datetime) as DT1";
   // XXX(bnoordhuis) sqlite3 has no distinct DATETIME or TIMESTAMP type.
@@ -34,7 +35,10 @@ db.open(common.connectionString, function(err) {
         assert.equal(data[0].DT1, ds.replace('T', ' ').replace(/\.\d+$/, ''));
       } else {
         assert.equal(data[0].DT1.constructor.name, "Date", "DT1 is not an instance of a Date object");
-        assert.equal(data[0].DT1.getTime(), dt.getTime());
+        // XXX(bnoordhuis) DT1 is in local time but we inserted
+        // a UTC date so we need to adjust it before comparing.
+        dt = new Date(dt.getTime() + 6e4 * dt.getTimezoneOffset());
+        assert.equal(data[0].DT1.toISOString(), dt.toISOString());
       }
     });
   });

--- a/test/test-multi-openSync-closeSync.js
+++ b/test/test-multi-openSync-closeSync.js
@@ -16,7 +16,7 @@ for (var x = 0; x < openCount; x++ ) {
   }
   catch (e) {
     console.log(common.connectionString);
-    console.log(e);
+    console.log(e.stack);
     errorCount += 1;
     break;
   }

--- a/test/test-openSync.js
+++ b/test/test-openSync.js
@@ -18,7 +18,7 @@ try {
   db.openSync(common.connectionString);
 }
 catch(e) {
-  console.log(e);
+  console.log(e.stack);
   assert.deepEqual(e, null);
 }
 
@@ -26,6 +26,6 @@ try {
   db.closeSync();
 }
 catch(e) {
-  console.log(e);
+  console.log(e.stack);
   assert.deepEqual(e, null);
 }

--- a/test/test-query-create-table-fetchSync.js
+++ b/test/test-query-create-table-fetchSync.js
@@ -15,7 +15,7 @@ db.queryResult("create table " + common.tableName + " (COLINT INTEGER, COLDATETI
     console.log(data);
   }
   catch (e) {
-    console.log(e);
+    console.log(e.stack);
   }
   
   db.closeSync();

--- a/test/test-querySync-select-unicode.js
+++ b/test/test-querySync-select-unicode.js
@@ -11,7 +11,7 @@ try {
   data = db.querySync("select 'ꜨꜢ' as UNICODETEXT");
 }
 catch (e) {
-  console.log(e); 
+  console.log(e.stack);
 }
 
 db.closeSync();

--- a/test/test-querySync-select-with-execption.js
+++ b/test/test-querySync-select-with-execption.js
@@ -12,7 +12,7 @@ try {
   var data = db.querySync("select invalid query");
 }
 catch (e) {
-  console.log(e);
+  console.log(e.stack);
   
   err = e;
 }

--- a/test/test-transaction-commit-sync.js
+++ b/test/test-transaction-commit-sync.js
@@ -22,7 +22,7 @@ common.createTables(db, function (err, data) {
   }
   catch (e) {
     console.log("Failed when rolling back");
-    console.log(e);
+    console.log(e.stack);
     exitCode = 1
   }  
     
@@ -40,7 +40,7 @@ common.createTables(db, function (err, data) {
   }
   catch (e) {
     console.log("Failed when committing");
-    console.log(e);
+    console.log(e.stack);
     
     exitCode = 2;
   }


### PR DESCRIPTION
This makes the tests pass for me locally with the SQLite and MySQL/MariaDB drivers.  I unfortunately don't have a MSSQL instance to test against.

One caveat: the MySQL driver insists on `-DUNICODE` whereas the SQLite driver only seems to speaks UTF-8 and hence node-odbc needs to be compiled _without_ `-DUNICODE`.

I tried `CHARSET=utf8`with the MySQL driver but it mangles UTF-8 input in interesting ways.