### PR TITLE
Fix unref of uninitialized async handle.

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -39,7 +39,6 @@ using namespace v8;
 using namespace node;
 
 uv_mutex_t ODBC::g_odbcMutex;
-uv_async_t ODBC::g_async;
 
 Nan::Persistent<Function> ODBC::constructor;
 
@@ -79,22 +78,6 @@ void ODBC::Init(v8::Handle<Object> exports) {
   constructor.Reset(constructor_template->GetFunction());
   exports->Set(Nan::New("ODBC").ToLocalChecked(),
                constructor_template->GetFunction());
-  
-#if NODE_VERSION_AT_LEAST(0, 7, 9)
-  // Initialize uv_async so that we can prevent node from exiting
-  //uv_async_init( uv_default_loop(),
-  //               &ODBC::g_async,
-  //               ODBC::WatcherCallback);
-  
-  // Not sure if the init automatically calls uv_ref() because there is weird
-  // behavior going on. When ODBC::Init is called which initializes the 
-  // uv_async_t g_async above, there seems to be a ref which will keep it alive
-  // but we only want this available so that we can uv_ref() later on when
-  // we have a connection.
-  // so to work around this, I am possibly mistakenly calling uv_unref() once
-  // so that there are no references on the loop.
-  //uv_unref((uv_handle_t *)&ODBC::g_async);
-#endif
   
   // Initialize the cross platform mutex provided by libuv
   uv_mutex_init(&ODBC::g_odbcMutex);

--- a/src/odbc.h
+++ b/src/odbc.h
@@ -75,7 +75,6 @@ class ODBC : public Nan::ObjectWrap {
   public:
     static Nan::Persistent<Function> constructor;
     static uv_mutex_t g_odbcMutex;
-    static uv_async_t g_async;
     
     static void Init(v8::Handle<Object> exports);
     static Column* GetColumns(SQLHSTMT hStmt, short* colCount);

--- a/src/odbc_connection.cpp
+++ b/src/odbc_connection.cpp
@@ -307,13 +307,6 @@ void ODBCConnection::UV_AfterOpen(uv_work_t* req, int status) {
 
   if (!err) {
    data->conn->self()->connected = true;
-    
-    //only uv_ref if the connection was successful
-//#if NODE_VERSION_AT_LEAST(0, 7, 9)
-//    uv_ref((uv_handle_t *)&ODBC::g_async);
-//#else
-//    uv_ref(uv_default_loop());
-//#endif
   }
 
   Nan::TryCatch try_catch;
@@ -419,13 +412,6 @@ NAN_METHOD(ODBCConnection::OpenSync) {
     ret = SQLFreeHandle( SQL_HANDLE_STMT, hStmt);
     
     conn->self()->connected = true;
-    
-    //only uv_ref if the connection was successful
-    /*#if NODE_VERSION_AT_LEAST(0, 7, 9)
-      uv_ref((uv_handle_t *)&ODBC::g_async);
-    #else
-      uv_ref(uv_default_loop());
-    #endif*/
   }
 
   uv_mutex_unlock(&ODBC::g_odbcMutex);
@@ -504,13 +490,6 @@ void ODBCConnection::UV_AfterClose(uv_work_t* req, int status) {
   }
   else {
     conn->connected = false;
-    
-    //only unref if the connection was closed
-//#if NODE_VERSION_AT_LEAST(0, 7, 9)
-//    uv_unref((uv_handle_t *)&ODBC::g_async);
-//#else
-//    uv_unref(uv_default_loop());
-//#endif
   }
 
   Nan::TryCatch try_catch;
@@ -545,12 +524,6 @@ NAN_METHOD(ODBCConnection::CloseSync) {
   
   conn->connected = false;
 
-#if NODE_VERSION_AT_LEAST(0, 7, 9)
-  uv_unref((uv_handle_t *)&ODBC::g_async);
-#else
-  uv_unref(uv_default_loop());
-#endif
-  
   info.GetReturnValue().Set(Nan::True());
 }
 


### PR DESCRIPTION
`ODBCConnection::CloseSync()` tried to unref a `uv_async_t` which
hadn't been initialized.

Remove the handle altogether, it isn't used anywhere else anymore,
and the ersatz reference counting scheme it was used for is taken
care of by `uv_queue_work()`.