### PR TITLE
Added ODBCConnection::GetInfoSync using SQLGetInfo

### DIFF
--- a/src/odbc.cpp
+++ b/src/odbc.cpp
@@ -68,6 +68,7 @@ void ODBC::Init(v8::Handle<Object> exports) {
   constructor_template->Set(Nan::New<String>("SQL_RESET_PARAMS").ToLocalChecked(), Nan::New<Number>(SQL_RESET_PARAMS), constant_attributes);
   constructor_template->Set(Nan::New<String>("SQL_DESTROY").ToLocalChecked(), Nan::New<Number>(SQL_DESTROY), constant_attributes);
   constructor_template->Set(Nan::New<String>("FETCH_ARRAY").ToLocalChecked(), Nan::New<Number>(FETCH_ARRAY), constant_attributes);
+  constructor_template->Set(Nan::New<String>("SQL_USER_NAME").ToLocalChecked(), Nan::New<Number>(SQL_USER_NAME), constant_attributes);
   NODE_ODBC_DEFINE_CONSTANT(constructor_template, FETCH_OBJECT);
   
   // Prototype Methods

--- a/src/odbc_connection.h
+++ b/src/odbc_connection.h
@@ -106,6 +106,7 @@ public:
     static NAN_METHOD(QuerySync);
     static NAN_METHOD(BeginTransactionSync);
     static NAN_METHOD(EndTransactionSync);
+    static NAN_METHOD(GetInfoSync);
 protected:
 
     struct Fetch_Request {


### PR DESCRIPTION
Synchronous implementation of SQLGetInfo via getInfoSync. Currently only supports SQL_USER_NAME as an argument. Also added SQL_USER_NAME as a constant within ODBC.